### PR TITLE
Missing parens in tuple pretty printer

### DIFF
--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -241,8 +241,8 @@ instance Pretty (Expr a) where
    pretty (Tuple { tuple_exprs = es }) =
       case es of
          [] -> text "()"
-         [e] -> pretty e <> comma
-         _ -> commaList es
+         [e] -> text "(" <> pretty e <> comma <> text ")"
+         _ -> text "(" <> commaList es <> text ")"
    pretty (Yield { yield_expr = e })
       = text "yield" <+> pretty e
    pretty (List { list_exprs = es }) = brackets (commaList es)


### PR DESCRIPTION
The non-unit tuples weren't being pretty printed with parens.  Is the user supposed to add parens manually
with the parentheses expression?

If not, this patch adds them in the pretty printer.
