### PR TITLE
Increased upper bound on `arrays` dependency

### DIFF
--- a/language-python.cabal
+++ b/language-python.cabal
@@ -34,7 +34,7 @@ Library
       base == 4.*,
       containers == 0.5.*,
       pretty == 1.1.*,
-      array == 0.4.*,
+      array >= 0.4 && < 0.6,
       transformers == 0.3.*,
       monads-tf == 0.1.*
    build-tools:      happy, alex


### PR DESCRIPTION
This allows `language-python` to compile against the latest Haskell Platform
