### PR TITLE
Allow recent transformers (and thus ghc 8.0)

### DIFF
--- a/language-python.cabal
+++ b/language-python.cabal
@@ -30,7 +30,7 @@ Library
       containers == 0.5.*,
       pretty == 1.1.*,
       array >= 0.4 && < 0.6,
-      transformers >= 0.3 && < 0.5,
+      transformers >= 0.3 && < 0.6,
       monads-tf == 0.1.*,
       utf8-string >= 1 && < 2
    build-tools: happy, alex


### PR DESCRIPTION
transformers 0.4 doesn't build on ghc 8.0. transformers 0.5 does, and language-python seems to compile just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bjpop/language-python/29)
<!-- Reviewable:end -->
