### PR TITLE
Fix #32: separate items in assign_to by equals signs instead of commas

### DIFF
--- a/src/Language/Python/Common/Pretty.hs
+++ b/src/Language/Python/Common/Pretty.hs
@@ -48,6 +48,10 @@ perhaps (Just {}) doc = doc
 commaList :: Pretty a => [a] -> Doc
 commaList = hsep . punctuate comma . map pretty 
 
+-- | A list of things separated by equals signs.
+equalsList :: Pretty a => [a] -> Doc
+equalsList = hsep . punctuate (space <> equals) . map pretty
+
 instance Pretty Int where
   pretty = int
 

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -112,7 +112,7 @@ instance Pretty (Statement a) where
            [] -> error "Attempt to pretty print conditional statement with empty guards"
    -- XXX is the assign_to always a singleton?
    pretty (Assign { assign_to = pattern, assign_expr = e })
-      = commaList pattern <+> equals <+> pretty e
+      = equalsList pattern <+> equals <+> pretty e
    pretty (AugmentedAssign { aug_assign_to = to_expr, aug_assign_op = op, aug_assign_expr = e})
       = pretty to_expr <+> pretty op <+> pretty e 
    pretty (Decorated { decorated_decorators = decs, decorated_def = stmt})


### PR DESCRIPTION
Fix for #32.

Both "x, y = 1" and "x = y = 1" are parsed correctly.
Parsing "x, y = 1" yields an `Assign` node with an `assign_to` list of a single `Tuple` (which holds the two `Var`s for x and y).
Parsing "x = y = 1" yields an `Assign` node with an `assign_to` list of two `Var`s for x and y.

Printing, however, separates items in the `assign_to` list by commas, which is incorrect.