### PR TITLE
Add new Python 3.5/3.6 Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 *.o
 .cabal-sandbox
 cabal.sandbox.config
+.idea
+language-python.iml
+.stack-work

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -271,6 +271,12 @@ data Statement annot
      , aug_assign_expr :: Expr annot  -- ^ Expression to evaluate.
      , stmt_annot :: annot
      }
+   | AnnotatedAssign
+    { ann_assign_annotation :: Expr annot
+    , ann_assign_to :: Maybe (Expr annot)
+    , ann_assign_expr :: Expr annot
+    , stmt_annot :: annot
+    }
    -- | Decorated definition of a function or class.
    | Decorated 
      { decorated_decorators :: [Decorator annot] -- ^ Decorators.

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -537,7 +537,8 @@ instance Span ComprehensionExprSpan where
 -- | Comprehension \'for\' component. 
 data CompFor annot = 
    CompFor 
-   { comp_for_exprs :: [Expr annot]
+   { comp_for_async :: Bool
+   , comp_for_exprs :: [Expr annot]
    , comp_in_expr :: Expr annot
    , comp_for_iter :: Maybe (CompIter annot) 
    , comp_for_annot :: annot

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -748,6 +748,7 @@ data Op annot
    | Minus { op_annot :: annot } -- ^ \'-\'
    | Divide { op_annot :: annot } -- ^ \'\/\'
    | FloorDivide { op_annot :: annot } -- ^ \'\/\/\'
+   | MatrixMult { op_annot :: annot } -- ^ \'@\'
    | Invert { op_annot :: annot } -- ^ \'~\' (bitwise inversion of its integer argument)
    | Modulo { op_annot :: annot } -- ^ \'%\'
    deriving (Eq,Ord,Show,Typeable,Data,Functor)
@@ -774,6 +775,7 @@ data AssignOp annot
    | LeftShiftAssign { assignOp_annot :: annot } -- ^ \'<<=\'
    | RightShiftAssign { assignOp_annot :: annot } -- ^ \'>>=\'
    | FloorDivAssign { assignOp_annot :: annot } -- ^ \'\/\/=\'
+   | MatrixMultAssign { assignOp_annot :: annot } -- ^ \'@=\'
    deriving (Eq,Ord,Show,Typeable,Data,Functor)
 
 type AssignOpSpan = AssignOp SrcSpan

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -229,6 +229,10 @@ data Statement annot
      , for_else :: Suite annot -- ^ Else clause.
      , stmt_annot :: annot
      }
+   | AsyncFor
+     { for_stmt :: Statement annot -- ^ For statement
+     , stmt_annot :: annot
+     }
    -- | Function definition. 
    | Fun 
      { fun_name :: Ident annot -- ^ Function name.
@@ -236,6 +240,10 @@ data Statement annot
      , fun_result_annotation :: Maybe (Expr annot) -- ^ Optional result annotation.
      , fun_body :: Suite annot -- ^ Function body.
      , stmt_annot :: annot 
+     }
+   | AsyncFun
+     { fun_def :: Statement annot -- ^ Function definition (Fun)
+     , stmt_annot :: annot
      }
    -- | Class definition. 
    | Class 
@@ -293,6 +301,10 @@ data Statement annot
      , with_body :: Suite annot -- ^ Suite to be managed.
      , stmt_annot :: annot
      }
+   | AsyncWith
+      { with_stmt :: Statement annot -- ^ With statement
+      , stmt_annot :: annot
+      }
    -- | Pass statement (null operation). 
    | Pass { stmt_annot :: annot }
    -- | Break statement (may only occur syntactically nested in a for or while loop, but not nested in a function or class definition within that loop). 
@@ -635,6 +647,8 @@ data Expr annot
      }
    -- | Generator. 
    | Generator { gen_comprehension :: Comprehension annot, expr_annot :: annot }
+   -- | Await
+   | Await { await_expr :: Expr annot, expr_annot :: annot }
    -- | List comprehension. 
    | ListComp { list_comprehension :: Comprehension annot, expr_annot :: annot }
    -- | List. 

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -273,8 +273,8 @@ data Statement annot
      }
    | AnnotatedAssign
     { ann_assign_annotation :: Expr annot
-    , ann_assign_to :: Maybe (Expr annot)
-    , ann_assign_expr :: Expr annot
+    , ann_assign_to :: Expr annot
+    , ann_assign_expr :: Maybe (Expr annot)
     , stmt_annot :: annot
     }
    -- | Decorated definition of a function or class.

--- a/src/Language/Python/Common/AST.hs
+++ b/src/Language/Python/Common/AST.hs
@@ -44,7 +44,7 @@ module Language.Python.Common.AST (
    , Op (..), OpSpan
    , Argument (..), ArgumentSpan
    , Slice (..), SliceSpan
-   , DictMappingPair (..), DictMappingPairSpan
+   , DictKeyDatumList (..), DictKeyDatumListSpan
    , YieldArg (..), YieldArgSpan
    -- * Imports
    , ImportItem (..), ImportItemSpan
@@ -525,7 +525,7 @@ instance Annotated Comprehension where
 
 data ComprehensionExpr annot
    = ComprehensionExpr (Expr annot)
-   | ComprehensionDict (DictMappingPair annot) 
+   | ComprehensionDict (DictKeyDatumList annot)
    deriving (Eq,Ord,Show,Typeable,Data,Functor)
 
 type ComprehensionExprSpan = ComprehensionExpr SrcSpan
@@ -655,7 +655,7 @@ data Expr annot
    -- | List. 
    | List { list_exprs :: [Expr annot], expr_annot :: annot }
    -- | Dictionary. 
-   | Dictionary { dict_mappings :: [DictMappingPair annot], expr_annot :: annot }
+   | Dictionary { dict_mappings :: [DictKeyDatumList annot], expr_annot :: annot }
    -- | Dictionary comprehension. /Version 3 only/. 
    | DictComp { dict_comprehension :: Comprehension annot, expr_annot :: annot }
    -- | Set. 
@@ -689,14 +689,16 @@ instance Span YieldArgSpan where
 instance Annotated Expr where
    annot = expr_annot 
 
-data DictMappingPair annot =
+data DictKeyDatumList annot =
    DictMappingPair (Expr annot) (Expr annot)
+   | DictUnpacking (Expr annot)
    deriving (Eq,Ord,Show,Typeable,Data,Functor)
 
-type DictMappingPairSpan = DictMappingPair SrcSpan 
+type DictKeyDatumListSpan = DictKeyDatumList SrcSpan
 
-instance Span DictMappingPairSpan where
+instance Span DictKeyDatumListSpan where
    getSpan (DictMappingPair e1 e2) = spanning e1 e2
+   getSpan (DictUnpacking e) = getSpan e
 
 -- | Slice compenent.
 data Slice annot

--- a/src/Language/Python/Common/LexerUtils.hs
+++ b/src/Language/Python/Common/LexerUtils.hs
@@ -147,6 +147,12 @@ rawStringToken = StringToken
 byteStringToken :: SrcSpan -> String -> Token
 byteStringToken = ByteStringToken
 
+formatStringToken :: SrcSpan -> String -> Token
+formatStringToken = StringToken
+
+formatRawStringToken :: SrcSpan -> String -> Token
+formatRawStringToken = StringToken
+
 unicodeStringToken :: SrcSpan -> String -> Token
 unicodeStringToken = UnicodeStringToken
 

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -102,20 +102,23 @@ makeTupleOrExpr es@(_:_) Nothing  = Tuple es (getSpan es)
 makeAssignmentOrExpr :: ExprSpan -> Either [ExprSpan] (AssignOpSpan, ExprSpan) -> StatementSpan
 makeAssignmentOrExpr e (Left es) 
    = makeNormalAssignment e es
-   where
-   makeNormalAssignment :: ExprSpan -> [ExprSpan] -> StatementSpan
-   makeNormalAssignment e [] = StmtExpr e (getSpan e)
-   makeNormalAssignment e es 
-      = AST.Assign (e : front) (head back) (spanning e es)
-      where
-      (front, back) = splitAt (len - 1) es
-      len = length es 
-makeAssignmentOrExpr e1 (Right (op, e2)) 
-   = makeAugAssignment e1 op e2
-   where
-   makeAugAssignment :: ExprSpan -> AssignOpSpan -> ExprSpan -> StatementSpan
-   makeAugAssignment e1 op e2
-      = AST.AugmentedAssign e1 op e2 (spanning e1 e2)
+makeAssignmentOrExpr e (Right ope2)
+   = makeAugAssignment e ope2
+
+makeAugAssignment :: ExprSpan -> (AssignOpSpan, ExprSpan) -> StatementSpan
+makeAugAssignment e1 (op, e2)
+  = AST.AugmentedAssign e1 op e2 (spanning e1 e2)
+
+makeNormalAssignment :: ExprSpan -> [ExprSpan] -> StatementSpan
+makeNormalAssignment e [] = StmtExpr e (getSpan e)
+makeNormalAssignment e es
+  = AST.Assign (e : front) (head back) (spanning e es)
+  where
+  (front, back) = splitAt (len - 1) es
+  len = length es
+
+makeAnnAssignment :: ExprSpan -> (ExprSpan, Maybe ExprSpan) -> StatementSpan
+makeAnnAssignment ae (annotation, ato) = AST.AnnotatedAssign annotation ato ae (spanning ae ato)
 
 makeTry :: Token -> SuiteSpan -> ([HandlerSpan], [StatementSpan], [StatementSpan]) -> StatementSpan
 makeTry t1 body (handlers, elses, finally)

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -118,7 +118,7 @@ makeNormalAssignment e es
   len = length es
 
 makeAnnAssignment :: ExprSpan -> (ExprSpan, Maybe ExprSpan) -> StatementSpan
-makeAnnAssignment ae (annotation, ato) = AST.AnnotatedAssign annotation ato ae (spanning ae ato)
+makeAnnAssignment ato (annotation, ae) = AST.AnnotatedAssign annotation ato ae (spanning ae ato)
 
 makeTry :: Token -> SuiteSpan -> ([HandlerSpan], [StatementSpan], [StatementSpan]) -> StatementSpan
 makeTry t1 body (handlers, elses, finally)

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -158,11 +158,21 @@ makeSet :: ExprSpan -> Either CompForSpan [ExprSpan] -> SrcSpan -> ExprSpan
 makeSet e (Left compFor) = SetComp (Comprehension (ComprehensionExpr e) compFor (spanning e compFor))
 makeSet e (Right es) = Set (e:es)
 
-makeDictionary :: (ExprSpan, ExprSpan) -> Either CompForSpan [(ExprSpan,ExprSpan)] -> SrcSpan -> ExprSpan
-makeDictionary mapping@(key, val) (Left compFor) =
+-- The Either (ExprSpan, ExprSpan) ExprSpan refers to a (key, value) pair or a dictionary unpacking expression.
+makeDictionary :: Either (ExprSpan, ExprSpan) ExprSpan -> Either CompForSpan [Either (ExprSpan, ExprSpan) ExprSpan] -> SrcSpan -> ExprSpan
+makeDictionary (Left mapping@(key, val)) (Left compFor) =
    DictComp (Comprehension (ComprehensionDict (DictMappingPair key val)) compFor (spanning mapping compFor))
-makeDictionary (key, val) (Right es) =
-   Dictionary (DictMappingPair key val: map (\(e1, e2) -> DictMappingPair e1 e2) es)
+-- This is allowed by the grammar, but will produce a runtime syntax error:
+-- dict unpacking cannot be used in dict comprehension
+makeDictionary (Right unpacking) (Left compFor) =
+   DictComp (Comprehension (ComprehensionDict (DictUnpacking unpacking)) compFor (spanning unpacking compFor))
+makeDictionary item (Right es) = Dictionary $ toKeyDatumList <$> item : es
+
+
+toKeyDatumList :: Either (ExprSpan, ExprSpan) ExprSpan -> DictKeyDatumList SrcSpan
+toKeyDatumList (Left (key, value)) = DictMappingPair key value
+toKeyDatumList (Right unpacking) = DictUnpacking unpacking
+
 
 fromEither :: Either a a -> a
 fromEither (Left x) = x

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -96,10 +96,12 @@ instance Pretty (Statement a) where
    pretty stmt@(For {})
       = text "for" <+> commaList (for_targets stmt) <+> text "in" <+> pretty (for_generator stmt) <> colon $+$
         indent (prettySuite (for_body stmt)) $+$ optionalKeywordSuite "else" (for_else stmt)
+   pretty (AsyncFor { for_stmt = fs }) = zeroWidthText "async " <> pretty fs
    pretty stmt@(Fun {})
       = text "def" <+> pretty (fun_name stmt) <> parens (commaList (fun_args stmt)) <+> 
         perhaps (fun_result_annotation stmt) (text "->") <+>
         pretty (fun_result_annotation stmt) <> colon $+$ indent (prettySuite (fun_body stmt)) 
+   pretty (AsyncFun { fun_def = fd }) = text "async" <+> pretty fd
    pretty stmt@(Class {})
       = text "class" <+> pretty (class_name stmt) <> prettyOptionalList (class_args stmt) <> 
         colon $+$ indent (prettySuite (class_body stmt)) 
@@ -127,6 +129,7 @@ instance Pretty (Statement a) where
    pretty (With { with_context = context, with_body = body })
       = text "with" <+> hcat (punctuate comma (map prettyWithContext context)) <+> colon $+$
         indent (prettySuite body)
+   pretty (AsyncWith { with_stmt = ws }) = text "async" <+> pretty ws
    pretty Pass {} = text "pass"
    pretty Break {} = text "break"
    pretty Continue {} = text "continue"
@@ -250,6 +253,7 @@ instance Pretty (Expr a) where
    pretty (Yield { yield_arg = arg })
       = text "yield" <+> pretty arg 
    pretty (Generator { gen_comprehension = gc }) = parens $ pretty gc
+   pretty (Await { await_expr = ae }) = text "await" <+> pretty ae
    pretty (ListComp { list_comprehension = lc }) = brackets $ pretty lc
    pretty (List { list_exprs = es }) = brackets (commaList es)
    pretty (Dictionary { dict_mappings = mappings })

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -119,7 +119,7 @@ instance Pretty (Statement a) where
    pretty (AugmentedAssign { aug_assign_to = to_expr, aug_assign_op = op, aug_assign_expr = e})
       = pretty to_expr <+> pretty op <+> pretty e
    pretty (AnnotatedAssign { ann_assign_annotation = ann_annotate, ann_assign_to = ann_to, ann_assign_expr = ann_expr})
-      = pretty ann_expr <+> text ":" <+> pretty ann_annotate <+> fromMaybe empty (((text "=" <+>) . pretty) <$> ann_to)
+      = pretty ann_to <+> text ":" <+> pretty ann_annotate <+> fromMaybe empty (((text "=" <+>) . pretty) <$> ann_expr)
    pretty (Decorated { decorated_decorators = decs, decorated_def = stmt})
       = vcat (map pretty decs) $+$ pretty stmt
    pretty (Return { return_expr = e }) = text "return" <+> pretty e

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -13,7 +13,8 @@
 module Language.Python.Common.PrettyAST () where
 
 import Language.Python.Common.Pretty
-import Language.Python.Common.AST 
+import Language.Python.Common.AST
+import Data.Maybe (isJust, fromMaybe)
 
 --------------------------------------------------------------------------------
 
@@ -116,7 +117,9 @@ instance Pretty (Statement a) where
    pretty (Assign { assign_to = pattern, assign_expr = e })
       = equalsList pattern <+> equals <+> pretty e
    pretty (AugmentedAssign { aug_assign_to = to_expr, aug_assign_op = op, aug_assign_expr = e})
-      = pretty to_expr <+> pretty op <+> pretty e 
+      = pretty to_expr <+> pretty op <+> pretty e
+   pretty (AnnotatedAssign { ann_assign_annotation = ann_annotate, ann_assign_to = ann_to, ann_assign_expr = ann_expr})
+      = pretty ann_expr <+> text ":" <+> pretty ann_annotate <+> fromMaybe empty (((text "=" <+>) . pretty) <$> ann_to)
    pretty (Decorated { decorated_decorators = decs, decorated_def = stmt})
       = vcat (map pretty decs) $+$ pretty stmt
    pretty (Return { return_expr = e }) = text "return" <+> pretty e

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -208,8 +208,9 @@ instance Pretty (ComprehensionExpr a) where
    pretty (ComprehensionDict d) = pretty d
 
 instance Pretty (CompFor a) where
-   pretty (CompFor { comp_for_exprs = es, comp_in_expr = e, comp_for_iter = iter }) 
-      = text "for" <+> commaList es <+> text "in" <+> pretty e <+> pretty iter
+   pretty (CompFor { comp_for_async = ca, comp_for_exprs = es, comp_in_expr = e, comp_for_iter = iter })
+      = (text $ if ca then "async for" else "for") <+> commaList es
+      <+> text "in" <+> pretty e <+> pretty iter
 
 instance Pretty (CompIf a) where
    pretty (CompIf { comp_if = e, comp_if_iter = iter }) 

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -101,7 +101,7 @@ instance Pretty (Statement a) where
       = text "def" <+> pretty (fun_name stmt) <> parens (commaList (fun_args stmt)) <+> 
         perhaps (fun_result_annotation stmt) (text "->") <+>
         pretty (fun_result_annotation stmt) <> colon $+$ indent (prettySuite (fun_body stmt)) 
-   pretty (AsyncFun { fun_def = fd }) = text "async" <+> pretty fd
+   pretty (AsyncFun { fun_def = fd }) = zeroWidthText "async " <+> pretty fd
    pretty stmt@(Class {})
       = text "class" <+> pretty (class_name stmt) <> prettyOptionalList (class_args stmt) <> 
         colon $+$ indent (prettySuite (class_body stmt)) 
@@ -129,7 +129,7 @@ instance Pretty (Statement a) where
    pretty (With { with_context = context, with_body = body })
       = text "with" <+> hcat (punctuate comma (map prettyWithContext context)) <+> colon $+$
         indent (prettySuite body)
-   pretty (AsyncWith { with_stmt = ws }) = text "async" <+> pretty ws
+   pretty (AsyncWith { with_stmt = ws }) = zeroWidthText "async " <+> pretty ws
    pretty Pass {} = text "pass"
    pretty Break {} = text "break"
    pretty Continue {} = text "continue"

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -305,6 +305,7 @@ instance Pretty (Op a) where
    pretty (Minus {}) = text "-"
    pretty (Divide {}) = text "/"
    pretty (FloorDivide {}) = text "//"
+   pretty (MatrixMult {}) = text "@"
    pretty (Invert {}) = text "~"
    pretty (Modulo {}) = text "%"
 
@@ -321,3 +322,4 @@ instance Pretty (AssignOp a) where
    pretty (LeftShiftAssign {}) = text "<<="
    pretty (RightShiftAssign {}) = text ">>="
    pretty (FloorDivAssign {}) = text "//="
+   pretty (MatrixMultAssign {}) = text "@="

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -270,8 +270,9 @@ instance Pretty (YieldArg a) where
    pretty (YieldFrom e _annot) = text "from" <+> pretty e
    pretty (YieldExpr e) = pretty e
 
-instance Pretty (DictMappingPair a) where
+instance Pretty (DictKeyDatumList a) where
    pretty (DictMappingPair key val) = pretty key <> colon <+> pretty val
+   pretty (DictUnpacking expr) = text "**" <> pretty expr
 
 instance Pretty (Slice a) where
    pretty (SliceProper { slice_lower = lower, slice_upper = upper, slice_stride = stride })

--- a/src/Language/Python/Common/PrettyToken.hs
+++ b/src/Language/Python/Common/PrettyToken.hs
@@ -106,6 +106,7 @@ instance Pretty Token where
         LeftShiftAssignToken {} -> text "<<="
         RightShiftAssignToken {} -> text ">>="
         FloorDivAssignToken {} -> text "//="
+        MatrixMultAssignToken {} -> text "@="
         BackQuoteToken {} -> text "` (back quote)"
         PlusToken {} -> text "+"
         MinusToken {} -> text "-"

--- a/src/Language/Python/Common/PrettyToken.hs
+++ b/src/Language/Python/Common/PrettyToken.hs
@@ -65,6 +65,8 @@ instance Pretty Token where
         AsToken {} -> text "as"
         ElifToken {} -> text "elif"
         YieldToken {} -> text "yield"
+        AsyncToken {} -> text "async"
+        AwaitToken {} -> text "await"
         AssertToken {} -> text "assert"
         ImportToken {} -> text "import"
         PassToken {} -> text "pass"

--- a/src/Language/Python/Common/Token.hs
+++ b/src/Language/Python/Common/Token.hs
@@ -86,6 +86,8 @@ data Token
    | OrToken { token_span :: !SrcSpan }                           -- ^ Keyword: boolean disjunction \'or\'.
    -- Version 3.x only:
    | NonLocalToken { token_span :: !SrcSpan }                     -- ^ Keyword: \'nonlocal\' (Python 3.x only)
+   | AsyncToken { token_span :: !SrcSpan }                        -- ^ Keyword: \'async\' (Python 3.x only)
+   | AwaitToken { token_span :: !SrcSpan }                        -- ^ Keyword: \'await\' (Python 3.x only)
    -- Version 2.x only:
    | PrintToken { token_span :: !SrcSpan }                        -- ^ Keyword: \'print\'. (Python 2.x only)
    | ExecToken { token_span :: !SrcSpan }                         -- ^ Keyword: \'exec\'. (Python 2.x only)
@@ -220,6 +222,8 @@ classifyToken token =
       AsToken {} -> Keyword 
       ElifToken {} -> Keyword 
       YieldToken {} -> Keyword 
+      AsyncToken {} -> Keyword
+      AwaitToken {} -> Keyword
       AssertToken {} -> Keyword 
       ImportToken {} -> Keyword 
       PassToken {} -> Keyword 
@@ -322,6 +326,8 @@ tokenString token =
       AsToken {} -> "as"
       ElifToken {} -> "elif" 
       YieldToken {} -> "yield"
+      AsyncToken {} -> "async"
+      AwaitToken {} -> "await"
       AssertToken {} -> "assert" 
       ImportToken {} -> "import"
       PassToken {} -> "pass" 

--- a/src/Language/Python/Common/Token.hs
+++ b/src/Language/Python/Common/Token.hs
@@ -119,6 +119,7 @@ data Token
    | LeftShiftAssignToken { token_span :: !SrcSpan }              -- ^ Delimiter: binary-left-shift assignment \'<<=\'.
    | RightShiftAssignToken { token_span :: !SrcSpan }             -- ^ Delimiter: binary-right-shift assignment \'>>=\'.
    | FloorDivAssignToken { token_span :: !SrcSpan }               -- ^ Delimiter: floor-divide assignment \'//=\'.
+   | MatrixMultAssignToken { token_span :: !SrcSpan }             -- ^ Delimiter: matrix multiplication assignment \'@=\'.
    | BackQuoteToken { token_span :: !SrcSpan }                    -- ^ Delimiter: back quote character \'`\'.
 
    -- Operators
@@ -263,6 +264,7 @@ classifyToken token =
       LeftShiftAssignToken {} -> Assignment 
       RightShiftAssignToken {} -> Assignment 
       FloorDivAssignToken {} -> Assignment 
+      MatrixMultAssignToken {} -> Assignment
       BackQuoteToken {} -> Punctuation 
       PlusToken {} -> Operator 
       MinusToken {} -> Operator 
@@ -367,6 +369,7 @@ tokenString token =
       LeftShiftAssignToken {} -> "<<="
       RightShiftAssignToken {} -> ">>="
       FloorDivAssignToken {} -> "//=" 
+      MatrixMultAssignToken {} -> "@="
       BackQuoteToken {} -> "`"
       PlusToken {} -> "+"
       MinusToken {} -> "-"

--- a/src/Language/Python/Version2/Parser/Parser.y
+++ b/src/Language/Python/Version2/Parser/Parser.y
@@ -865,18 +865,18 @@ testlistrev
 
 dictorsetmaker :: { SrcSpan -> ExprSpan }
 dictorsetmaker
-   : test ':' test dict_rest { makeDictionary ($1, $3) $4 }
+   : test ':' test dict_rest { makeDictionary (Left ($1, $3)) $4 }
    | test set_rest { makeSet $1 $2 }
 
-dict_rest :: { Either CompForSpan [(ExprSpan, ExprSpan)] }
+dict_rest :: { Either CompForSpan [Either (ExprSpan, ExprSpan) ExprSpan] }
 dict_rest
    : comp_for { Left $1 }
    | zero_or_more_dict_mappings_rev opt_comma { Right (reverse $1) }
 
-zero_or_more_dict_mappings_rev :: { [(ExprSpan, ExprSpan)] }
+zero_or_more_dict_mappings_rev :: { [Either (ExprSpan, ExprSpan) ExprSpan] }
 zero_or_more_dict_mappings_rev
    : {- empty -} { [] }
-   | zero_or_more_dict_mappings_rev ',' test ':' test { ($3,$5) : $1 }
+   | zero_or_more_dict_mappings_rev ',' test ':' test { (Left ($3,$5)) : $1 }
 
 set_rest :: { Either CompForSpan [ExprSpan] }
 set_rest

--- a/src/Language/Python/Version2/Parser/Parser.y
+++ b/src/Language/Python/Version2/Parser/Parser.y
@@ -949,7 +949,7 @@ comp_iter
 comp_for :: { CompForSpan }
 comp_for
    : 'for' exprlist 'in' or_test opt(comp_iter)
-     { CompFor $2 $4 $5 (spanning (spanning $1 $4) $5) }
+     { CompFor False $2 $4 $5 (spanning (spanning $1 $4) $5) }
 
 -- comp_if: 'if' old_trest [comp_iter]
 
@@ -967,7 +967,7 @@ list_iter
 -- list_for: 'for' exprlist 'in' testlist_safe [list_iter]
 list_for :: { CompForSpan }
 list_for: 'for' exprlist 'in' testlist_safe opt(list_iter)
-          { AST.CompFor $2 $4 $5 (spanning (spanning $1 $4) $5) }
+          { AST.CompFor False $2 $4 $5 (spanning (spanning $1 $4) $5) }
 
 -- list_if: 'if' old_test [list_iter]
 
@@ -985,7 +985,7 @@ gen_iter
 
 gen_for :: { CompForSpan }
 gen_for: 'for' exprlist 'in' or_test opt(gen_iter)
-          { AST.CompFor $2 $4 $5 (spanning (spanning $1 $4) $5) }
+          { AST.CompFor False $2 $4 $5 (spanning (spanning $1 $4) $5) }
 
 -- gen_if: 'if' old_test [gen_iter]
 

--- a/src/Language/Python/Version3/Parser/Lexer.x
+++ b/src/Language/Python/Version3/Parser/Lexer.x
@@ -60,7 +60,9 @@ $not_double_quote = [. \n] # \"
 @byte_str_prefix = b | B
 @raw_str_prefix = r | R
 @unicode_str_prefix = u | U
+@format_str_prefix = f | F
 @raw_byte_str_prefix = @byte_str_prefix @raw_str_prefix | @raw_str_prefix @byte_str_prefix
+@format_raw_str_prefix = @format_str_prefix @raw_str_prefix | @raw_str_prefix @format_str_prefix
 @backslash_pair = \\ (\\|'|\"|@eol_pattern|$short_str_char)
 @backslash_pair_bs = \\ (\\|'|\"|@eol_pattern|$short_byte_str_char)
 @short_str_item_single = $short_str_char|@backslash_pair|\"
@@ -100,26 +102,34 @@ $white_no_nl+  ;  -- skip whitespace
 <0> {
    ' @short_str_item_single* ' { mkString stringToken }
    @raw_str_prefix ' @short_str_item_single* ' { mkString rawStringToken }
+   @format_str_prefix ' @short_str_item_single* ' { mkString formatStringToken }
    @byte_str_prefix ' @short_byte_str_item_single* ' { mkString byteStringToken }
    @raw_byte_str_prefix ' @short_byte_str_item_single* ' { mkString rawByteStringToken }
+   @format_raw_str_prefix ' @short_str_item_single* ' { mkString formatRawStringToken }
    @unicode_str_prefix ' @short_str_item_single* ' { mkString unicodeStringToken }
 
    \" @short_str_item_double* \" { mkString stringToken }
    @raw_str_prefix \" @short_str_item_double* \" { mkString rawStringToken }
+   @format_str_prefix \" @short_str_item_double* \" { mkString formatStringToken }
    @byte_str_prefix \" @short_byte_str_item_double* \" { mkString byteStringToken }
    @raw_byte_str_prefix \" @short_byte_str_item_double* \" { mkString rawByteStringToken }
+   @format_raw_str_prefix \" @short_str_item_double* \" { mkString formatRawStringToken }
    @unicode_str_prefix \" @short_str_item_double* \" { mkString unicodeStringToken }
 
    ''' @long_str_item_single* ''' { mkString stringToken }
    @raw_str_prefix ''' @long_str_item_single* ''' { mkString rawStringToken }
+   @format_str_prefix ''' @long_str_item_single* ''' { mkString formatStringToken }
    @byte_str_prefix ''' @long_byte_str_item_single* ''' { mkString byteStringToken }
    @raw_byte_str_prefix ''' @long_byte_str_item_single* ''' { mkString rawByteStringToken }
+   @format_raw_str_prefix ''' @long_str_item_single* ''' { mkString formatRawStringToken }
    @unicode_str_prefix ''' @long_str_item_single* ''' { mkString unicodeStringToken }
 
    \"\"\" @long_str_item_double* \"\"\" { mkString stringToken }
    @raw_str_prefix \"\"\" @long_str_item_double* \"\"\" { mkString rawStringToken }
+   @format_str_prefix \"\"\" @long_str_item_double* \"\"\" { mkString formatStringToken }
    @byte_str_prefix \"\"\" @long_byte_str_item_double* \"\"\" { mkString byteStringToken }
    @raw_byte_str_prefix \"\"\" @long_byte_str_item_double* \"\"\" { mkString rawByteStringToken }
+   @format_raw_str_prefix \"\"\" @long_str_item_double* \"\"\" { mkString formatRawStringToken }
    @unicode_str_prefix \"\"\" @long_str_item_double* \"\"\" { mkString unicodeStringToken }
 }
 

--- a/src/Language/Python/Version3/Parser/Lexer.x
+++ b/src/Language/Python/Version3/Parser/Lexer.x
@@ -282,5 +282,6 @@ keywordNames =
    , ("as", AsToken), ("elif", ElifToken), ("if", IfToken), ("or", OrToken), ("yield", YieldToken)
    , ("assert", AssertToken), ("else", ElseToken), ("import", ImportToken), ("pass", PassToken)
    , ("break", BreakToken), ("except", ExceptToken), ("in", InToken), ("raise", RaiseToken)
+   , ("async", AsyncToken), ("await", AwaitToken)
    ]
 }

--- a/src/Language/Python/Version3/Parser/Lexer.x
+++ b/src/Language/Python/Version3/Parser/Lexer.x
@@ -201,6 +201,7 @@ $white_no_nl+  ;  -- skip whitespace
     "<<=" { symbolToken LeftShiftAssignToken }
     ">>=" { symbolToken RightShiftAssignToken }
     "//=" { symbolToken FloorDivAssignToken } 
+    "@="  { symbolToken MatrixMultAssignToken }
     ","   { symbolToken CommaToken }
     "@"   { symbolToken AtToken }
     \;    { symbolToken SemiColonToken }

--- a/src/Language/Python/Version3/Parser/Parser.y
+++ b/src/Language/Python/Version3/Parser/Parser.y
@@ -76,6 +76,7 @@ import Data.Maybe (isJust, maybeToList)
    '<<='           { LeftShiftAssignToken {} }
    '>>='           { RightShiftAssignToken {} }
    '//='           { FloorDivAssignToken {} } 
+   '@='            { MatrixMultAssignToken {} }
    '@'             { AtToken {} }
    '->'            { RightArrowToken {} }
    'and'           { AndToken {} }
@@ -371,7 +372,7 @@ test_list_star_rev
 
 {- 
    augassign: ('+=' | '-=' | '*=' | '/=' | '%=' | '&=' | '|=' | '^=' |
-            '<<=' | '>>=' | '**=' | '//=') 
+            '<<=' | '>>=' | '**=' | '//=' | '@=')
 -}
 
 augassign :: { AssignOpSpan }
@@ -388,6 +389,7 @@ augassign
    | '<<=' { AST.LeftShiftAssign (getSpan $1) }
    | '>>=' { AST.RightShiftAssign (getSpan $1) }
    | '//=' { AST.FloorDivAssign (getSpan $1) } 
+   | '@='  { AST.MatrixMultAssign (getSpan $1) }
 
 -- del_stmt: 'del' exprlist
 
@@ -761,6 +763,7 @@ mult_div_mod_op
    | '/'  { AST.Divide (getSpan $1) }
    | '%'  { AST.Modulo (getSpan $1) }
    | '//' { AST.FloorDivide (getSpan $1) }
+   | '@'  { AST.MatrixMult (getSpan $1) }
 
 -- factor: ('+'|'-'|'~') factor | power 
 

--- a/src/Language/Python/Version3/Parser/Parser.y
+++ b/src/Language/Python/Version3/Parser/Parser.y
@@ -20,7 +20,7 @@ import Language.Python.Common.ParserUtils
 import Language.Python.Common.ParserMonad
 import Language.Python.Common.SrcLocation
 import Data.Either (rights, either)
-import Data.Maybe (maybeToList)
+import Data.Maybe (isJust, maybeToList)
 }
 
 %name parseFileInput file_input 
@@ -970,8 +970,8 @@ comp_iter
 
 comp_for :: { CompForSpan }
 comp_for 
-   : 'for' exprlist 'in' or_test opt(comp_iter) 
-     { CompFor $2 $4 $5 (spanning (spanning $1 $4) $5) }
+   : opt('async') 'for' exprlist 'in' or_test opt(comp_iter)
+     { CompFor (isJust $1) $3 $5 $6 (spanning $1 (spanning (spanning $2 $5) $6)) }
 
 -- comp_if: 'if' test_nocond [comp_iter]
 


### PR DESCRIPTION
This pull request adds several (but not all) new syntax features in Python 3.5 and 3.6.

- [`PEP 492 - Coroutines with async and await syntax`](https://docs.python.org/3/whatsnew/3.5.html#whatsnew-pep-492)
- [`PEP 465 - A dedicated infix operator for matrix multiplication`](https://docs.python.org/3/whatsnew/3.5.html#whatsnew-pep-465)
- [`PEP 526: Syntax for variable annotations`](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep526)
- [`PEP 530: Asynchronous Comprehensions`](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep530)
- [`PEP 498: Formatted string literals`](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep498)
- Only the dictionary unpacking syntax of [`PEP 448 - Additional Unpacking Generalizations`](https://docs.python.org/3/whatsnew/3.5.html#whatsnew-pep-448)

Additional tests have been added in https://github.com/bjpop/language-python-test/pull/1