### PR TITLE
force ghc 7 for parser files to reduce build times

### DIFF
--- a/src/Language/Python/Version2/Parser/Parser.y
+++ b/src/Language/Python/Version2/Parser/Parser.y
@@ -1,4 +1,8 @@
 {
+{-# LANGUAGE CPP #-}
+
+#undef __GLASGOW_HASKELL__
+#define __GLASGOW_HASKELL__ 709
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Language.Python.Version2.Parser.Parser 

--- a/src/Language/Python/Version3/Parser/Parser.y
+++ b/src/Language/Python/Version3/Parser/Parser.y
@@ -1,4 +1,8 @@
 {
+{-# LANGUAGE CPP #-}
+
+#undef __GLASGOW_HASKELL__
+#define __GLASGOW_HASKELL__ 709
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Language.Python.Version3.Parser.Parser 


### PR DESCRIPTION
Fixes #41.

This is really just meant to be a temporary solution, since what this addresses is basically a GHC bug.

These changes should be undone once this bug's been fixed.

For more details, see the conversation in #41.