### PR TITLE
Fix warnings about incomplete patterns and unused imports.

### DIFF
--- a/src/Language/Python/Common/LexerUtils.hs
+++ b/src/Language/Python/Common/LexerUtils.hs
@@ -122,6 +122,7 @@ readBinary
    toBinary = foldl' acc 0
    acc b '0' = 2 * b
    acc b '1' = 2 * b + 1
+   acc _ _ = error "Lexer ensures all digits passed to readBinary are 0 or 1."
 
 readFloat :: String -> Double
 readFloat str@('.':cs) = read ('0':readFloatRest str)
@@ -230,3 +231,4 @@ lexicalError = do
 
 readOctNoO :: String -> Integer
 readOctNoO (zero:rest) = read (zero:'O':rest)
+readOctNoO [] = error "Lexer ensures readOctNoO is never called on an empty string"

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -257,9 +257,11 @@ checkArguments args = do
          ArgKeyword {}
             | state `elem` [1,2] -> check 2 rest
             | state `elem` [3,4] -> check 4 rest
+            | otherwise -> error "state should always be in range 1..4 here"
          ArgVarArgsPos {}
             | state `elem` [1,2] -> check 3 rest
             | state `elem` [3,4] -> spanError arg "there must not be two *arguments in an argument list"
+            | otherwise -> error "state should always be in range 1..4 here"
          ArgVarArgsKeyword {} -> check 5 rest
 
 {-
@@ -293,9 +295,11 @@ checkParameters params = do
          UnPackTuple {}
             | state `elem` [1,3] -> check state rest
             | state == 2 -> check 3 rest 
+            | otherwise -> error "state should always be in range 1..3 here"
          Param {}
             | state `elem` [1,3] -> check state rest
             | state == 2 -> check 3 rest 
+            | otherwise -> error "state should always be in range 1..3 here"
          EndPositional {}
             | state == 1 -> check 2 rest
             | otherwise -> spanError param "there must not be two *parameters in a parameter list"

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -98,6 +98,7 @@ makeTupleOrExpr :: [ExprSpan] -> Maybe Token -> ExprSpan
 makeTupleOrExpr [e] Nothing = e
 makeTupleOrExpr es@(_:_) (Just t) = Tuple es (spanning es t) 
 makeTupleOrExpr es@(_:_) Nothing  = Tuple es (getSpan es)
+makeTupleOrExpr [] _ = error "makeTupleOrExpr should never be called with an empty list"
 
 makeAssignmentOrExpr :: ExprSpan -> Either [ExprSpan] (AssignOpSpan, ExprSpan) -> StatementSpan
 makeAssignmentOrExpr e (Left es) 
@@ -188,6 +189,7 @@ makeDecorator t1 name args = Decorator name args (spanning t1 args)
 -- parser guarantees that the first list is non-empty
 makeDecorated :: [DecoratorSpan] -> StatementSpan -> StatementSpan
 makeDecorated ds@(d:_) def = Decorated ds def (spanning d def)
+makeDecorated [] _ = error "parser guarantees that makeDecorated's first argument is non-empty"
 
 -- suite can't be empty so it is safe to take span over it
 makeFun :: Token -> IdentSpan -> [ParameterSpan] -> Maybe ExprSpan -> SuiteSpan -> StatementSpan
@@ -220,6 +222,7 @@ makeRelative items =
    countDots count (Left token:rest) = countDots (count + dots token) rest 
    dots (DotToken {}) = 1
    dots (EllipsisToken {}) = 3
+   dots _ = error "Parser ensures dots is only called on DotToken or EllipsisToken."
 
 {-
    See: http://docs.python.org/3.0/reference/expressions.html#calls

--- a/src/Language/Python/Common/PrettyAST.hs
+++ b/src/Language/Python/Common/PrettyAST.hs
@@ -19,7 +19,7 @@ import Prelude hiding ((<>))
 
 import Language.Python.Common.Pretty
 import Language.Python.Common.AST
-import Data.Maybe (isJust, fromMaybe)
+import Data.Maybe (fromMaybe)
 
 --------------------------------------------------------------------------------
 

--- a/src/Language/Python/Common/PrettyParseError.hs
+++ b/src/Language/Python/Common/PrettyParseError.hs
@@ -15,7 +15,7 @@ module Language.Python.Common.PrettyParseError where
 import Language.Python.Common.Pretty
 import Language.Python.Common.ParseError (ParseError (..))
 import Language.Python.Common.SrcLocation 
-import Language.Python.Common.PrettyToken
+import Language.Python.Common.PrettyToken()
 
 instance Pretty ParseError where
     pretty (UnexpectedToken t) = pretty (getSpan t) <+> text "unexpected token:" <+> pretty t

--- a/src/Language/Python/Common/SrcLocation.hs
+++ b/src/Language/Python/Common/SrcLocation.hs
@@ -104,6 +104,7 @@ decColumn n loc
 incColumn :: Int -> SrcLocation -> SrcLocation
 incColumn n loc@(Sloc { sloc_column = col })
    = loc { sloc_column = col + n }
+incColumn _ NoLocation = NoLocation
 
 -- | Increment the column of a location by one tab stop.
 incTab :: SrcLocation -> SrcLocation
@@ -111,11 +112,13 @@ incTab loc@(Sloc { sloc_column = col })
    = loc { sloc_column = newCol } 
    where
    newCol = col + 8 - (col - 1) `mod` 8
+incTab NoLocation = NoLocation
 
 -- | Increment the line number (row) of a location by one.
 incLine :: Int -> SrcLocation -> SrcLocation
 incLine n loc@(Sloc { sloc_row = row }) 
    = loc { sloc_column = 1, sloc_row = row + n }
+incLine _ NoLocation = NoLocation
 
 {-
 Inspired heavily by compiler/basicTypes/SrcLoc.lhs 

--- a/src/Language/Python/Version3/Parser/Lexer.x
+++ b/src/Language/Python/Version3/Parser/Lexer.x
@@ -20,9 +20,6 @@ import Language.Python.Common.ParserMonad hiding (location)
 import Language.Python.Common.SrcLocation
 import Language.Python.Common.LexerUtils
 import qualified Data.Map as Map
-import Control.Monad (liftM)
-import Data.List (foldl')
-import Numeric (readHex, readOct)
 }
 
 -- character sets


### PR DESCRIPTION
See #46.

This fixes warnings of `-Wincomplete-patterns` and `-Wunused-imports` in a few places. There are still warnings about using the `deprecated` type `Control.Monad.Error` which are not fixed in this PR.

`-Wincomplete-patterns` is mostly fixed by adding patterns like `_ = error "reason why pattern is unreachable"`. `-Wunused-imports` is mostly fixed by just deleting the imports that it complained about. This included editing `Version3/Parser/Lexer.x` which is marked as being an auto-generated file, but it's checked in and I don't see what it was autogenerated from.

I have run [bjpop/language-python-test](https://github.com/bjpop/language-python-test) to confirm I didn't break anything.