### PR TITLE
Switch to using just Either instead of Error.

### DIFF
--- a/src/Language/Python/Common/LexerUtils.hs
+++ b/src/Language/Python/Common/LexerUtils.hs
@@ -14,7 +14,6 @@
 module Language.Python.Common.LexerUtils where
 
 import Control.Monad (liftM)
-import Control.Monad.Error.Class (throwError)
 import Data.List (foldl')
 import Data.Word (Word8)
 import Language.Python.Common.Token as Token

--- a/src/Language/Python/Common/ParseError.hs
+++ b/src/Language/Python/Common/ParseError.hs
@@ -14,14 +14,9 @@ module Language.Python.Common.ParseError ( ParseError (..) ) where
 
 import Language.Python.Common.SrcLocation (SrcLocation)
 import Language.Python.Common.Token (Token)
-import Control.Monad.Error.Class
 
 data ParseError  
    = UnexpectedToken Token           -- ^ An error from the parser. Token found where it should not be. Note: tokens contain their own source span.
    | UnexpectedChar Char SrcLocation -- ^ An error from the lexer. Character found where it should not be.
    | StrError String                 -- ^ A generic error containing a string message. No source location.
    deriving (Eq, Ord, Show)
-
-instance Error ParseError where
-   noMsg = StrError ""
-   strMsg = StrError 

--- a/src/Language/Python/Common/ParserMonad.hs
+++ b/src/Language/Python/Common/ParserMonad.hs
@@ -43,6 +43,7 @@ module Language.Python.Common.ParserMonad
    , addComment
    , getComments
    , spanError
+   , throwError
    ) where
 
 import Language.Python.Common.SrcLocation (SrcLocation (..), SrcSpan (..), Span (..))
@@ -51,7 +52,6 @@ import Language.Python.Common.ParseError (ParseError (..))
 import Control.Applicative ((<$>))
 import Control.Monad.State.Class
 import Control.Monad.State.Strict as State
-import Control.Monad.Error as Error
 import Language.Python.Common.Pretty
 
 internalError :: String -> P a 
@@ -90,6 +90,9 @@ initialState initLoc inp scStack
    }
 
 type P a = StateT ParseState (Either ParseError) a
+
+throwError :: ParseError -> P a
+throwError = lift . Left
 
 execParser :: P a -> ParseState -> Either ParseError a
 execParser = evalStateT 

--- a/src/Language/Python/Common/ParserUtils.hs
+++ b/src/Language/Python/Common/ParserUtils.hs
@@ -15,7 +15,6 @@ module Language.Python.Common.ParserUtils where
 
 import Data.List (foldl')
 import Data.Maybe (isJust)
-import Control.Monad.Error.Class (throwError)
 import Language.Python.Common.AST as AST
 import Language.Python.Common.Token as Token 
 import Language.Python.Common.ParserMonad hiding (location)


### PR DESCRIPTION
Gets rid of usages of `Error` by defining `throwError` as
```haskell
throwError :: ParseError -> P a
throwError = lift . Left
```
following [this StackOverflow answer](https://stackoverflow.com/a/31223291)'s recommendation to "Replace `Error` by nothing at all".

(I did try to use `Except` in https://github.com/dperelman/language-python/commit/866a8d719952e1be73d527842cbb94480c6485b1 ([`fix/parse-error`](https://github.com/dperelman/language-python/tree/fix/parse-error)) but that involved changing the external type of the parser, and I don't think there's any benefit to doing so. At the very least, this change eliminates the warning and maintains the existing functionality.)

This passes `language-python-test`. I also manually ran it on some files that are not valid Python files to confirm errors get printed as expected.

Fixes #46.