### PR TITLE
Disable redefining __GLASSGOW_HASKELL__ to fix compatibility with Happy 2.0.x

### DIFF
--- a/language-python/src/Language/Python/Version2/Parser/Parser.y
+++ b/language-python/src/Language/Python/Version2/Parser/Parser.y
@@ -1,8 +1,11 @@
 {
 {-# LANGUAGE CPP #-}
 
-#undef __GLASGOW_HASKELL__
+-- For legacy reasons
+#if __GLASGOW_HASKELL__ < 901 
+#undef __GLASGOW_HASKELL_
 #define __GLASGOW_HASKELL__ 709
+#endif 
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Language.Python.Version2.Parser.Parser 

--- a/language-python/src/Language/Python/Version3/Parser/Parser.y
+++ b/language-python/src/Language/Python/Version3/Parser/Parser.y
@@ -1,8 +1,12 @@
 {
 {-# LANGUAGE CPP #-}
 
+-- For legacy reasons
+#if __GLASGOW_HASKELL__ < 901 
 #undef __GLASGOW_HASKELL__
 #define __GLASGOW_HASKELL__ 709
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Language.Python.Version3.Parser.Parser 


### PR DESCRIPTION
This PR fixes issue #77. 

NOTE: I would like to remove the redefine entirely but since I am not sure what it's initial purpose was I only disable it for versions above GHC 9.1 which coincidentally correspond to the versions that do not perform an explicit type conversion from Int32# to Int#.